### PR TITLE
updated all atomate dependencies versions to update its version to 0.7.2

### DIFF
--- a/conda-skeletons/atomate/meta.yaml
+++ b/conda-skeletons/atomate/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "atomate" %}
-{% set version = "0.6.9" %}
-{% set md5 = "5fa406195071e602e171da8cf9158d46" %}
+{% set version = "0.7.2" %}
+{% set md5 = "f8ba5b1e244d1d866157ac60a4fa7670" %}
 
 package:
   name: '{{ name|lower }}'
@@ -21,14 +21,13 @@ requirements:
     - setuptools
   run:
     - python
-    - fireworks >=1.4.0
-    - pymatgen >=2017.8.16
-    - custodian >=1.1.0
-    - pymatgen-db >=0.5.1
-    - monty >=0.9.5
-    - tqdm >=4.7.4
+    - fireworks >=1.6.8
+    - pymatgen >=2018.2.13
+    - pymatgen-diffusion >=2018.1.4
+    - custodian >=2017.12.23
+    - paramiko >=2.1.2
     - six
-    - pymatgen-diffusion >=0.3.0
+    - pybtex >=0.21
 
 test:
   imports:

--- a/conda-skeletons/custodian/meta.yaml
+++ b/conda-skeletons/custodian/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "custodian" %}
-{% set version = "1.1.0" %}
-{% set md5 = "823579700fcb6add05dd580e0e437852" %}
+{% set version = "2017.12.23" %}
+{% set md5 = "2a24ce7dc47a57434d62696dfd10e58b" %}
 
 package:
   name: {{ name|lower }}
@@ -27,9 +27,9 @@ requirements:
     - setuptools
   run:
     - python
-    - monty >=0.9.0
+    - monty >=1.0.2
     - six
-    - pyyaml >=3.12
+    - ruamel.yaml >=0.15.35
 
 test:
   imports:

--- a/conda-skeletons/fireworks/meta.yaml
+++ b/conda-skeletons/fireworks/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "FireWorks" %}
-{% set version = "1.4.8" %}
-{% set md5 = "6eb467fa3d2164bd8c247775259da365" %}
+{% set version = "1.6.8" %}
+{% set md5 = "6a51e6c6901a4998e0ca80f0bd7bdd9a" %}
 
 package:
   name: {{ name|lower }}
@@ -36,6 +36,7 @@ requirements:
     - flask >=0.11.1
     - flask-paginate >=0.4.5
     - gunicorn >=19.6.0
+    - tqdm >=4.19.5
 
 test:
   # Python imports

--- a/conda-skeletons/palettable/meta.yaml
+++ b/conda-skeletons/palettable/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "palettable" %}
-{% set version = "2.1.1" %}
-{% set md5 = "60adcbda83e1eaa331c5fdc5dfbcc4ff" %}
+{% set version = "3.1.0" %}
+{% set md5 = "1fe822ae1379427360a2367e0cc588ba" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-skeletons/pybtex/meta.yaml
+++ b/conda-skeletons/pybtex/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pybtex" %}
-{% set version = "0.20.1" %}
-{% set md5 = "8c59ec6a7da00f68abb44a91a952dbe7" %}
+{% set version = "0.21" %}
+{% set md5 = "e7b320b2bcb34c664c4385533a2ea831" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-skeletons/pymatgen-diffusion/meta.yaml
+++ b/conda-skeletons/pymatgen-diffusion/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pymatgen-diffusion" %}
-{% set version = "0.3.0" %}
-{% set md5 = "40aa8ff8bc31f3e39767d5b54a60a2e8" %}
+{% set version = "2018.1.4" %}
+{% set md5 = "7a654541592e0dd27a264ac64fa51e79" %}
 
 package:
   name: {{ name|lower }}
@@ -21,8 +21,8 @@ requirements:
     - setuptools
   run:
     - python
-    - pymatgen >=4.4.11
-    - monty >=0.9.6
+    - pymatgen >=2018.2.13
+    - monty >=1.0.2
 
 test:
   imports:

--- a/conda-skeletons/pymatgen/meta.yaml
+++ b/conda-skeletons/pymatgen/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - python
     - setuptools
     - numpy >=1.9
-    - ruamel.yaml >=0.15.0
+    - ruamel.yaml >=0.15.35
   run:
     - python
     - setuptools
@@ -36,15 +36,15 @@ requirements:
     - numpy >=1.9
     - six
     - requests
-    - ruamel.yaml >=0.15.0
-    - monty >=1.0.0
-    - scipy >=0.14
+    - ruamel.yaml >=0.15.35
+    - monty >=1.0.2
+    - scipy >=1.0.0
     - sympy >=1.0.0
     - pydispatcher >=2.0.5
     - tabulate
-    - spglib >=1.9.8.7
-    - matplotlib >=1.5
-    - palettable >=2.1.1
+    - spglib >=1.10.3.39
+    - matplotlib >=2.1.2
+    - palettable >=3.1.0
     - enum34  # [py27]
 
 test:

--- a/conda-skeletons/ruamel.yaml/meta.yaml
+++ b/conda-skeletons/ruamel.yaml/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ruamel.yaml" %}
-{% set version = "0.15.34" %}
-{% set md5 = "786c5985a1ac660b9a031e6822b5961c" %}
+{% set version = "0.15.35" %}
+{% set md5 = "13b93b987fe1881b66c7cbccdf58c731" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-skeletons/spglib/meta.yaml
+++ b/conda-skeletons/spglib/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spglib" %}
-{% set version = "1.10.3.14" %}
-{% set md5 = "d7041a65f483192b225977986713b4a2" %}
+{% set version = "1.10.3.39" %}
+{% set md5 = "c662488be812c6e5565cc1d32c60c7a2" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-skeletons/tqdm/meta.yaml
+++ b/conda-skeletons/tqdm/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tqdm" %}
-{% set version = "4.10.0" %}
-{% set md5 = "2ed4ecde54bf9a6a989b3197dcccd56a" %}
+{% set version = "4.19.6" %}
+{% set md5 = "7d1390ee8353354fe54b2df07fceb898" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
With the new versions, I could build the following with python 2 on my Mac:

palettable 3.1.0
ruame.yaml 0.15.35
monty 1.0.2
spglib 1.10.3.39
pymatgen 2018.2.13
pymatgen-diffusion 2018.1.4
tqdm 4.19.6
fireworks 1.6.8
custodian 2017.12.23
pybtex 0.21
atomate 0.7.2