### PR TITLE
bring numpy to build requirement and update pymatgen-db version

### DIFF
--- a/conda-skeletons/pymatgen-db/meta.yaml
+++ b/conda-skeletons/pymatgen-db/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pymatgen-db" %}
-{% set version = "0.6.5" %}
-{% set md5 = "93671fddedd8c0aebd73c0bf3d2e7365" %}
+{% set version = "2018.2.21" %}
+{% set md5 = "95d4e7383128fc8019c0d72b00ce198b" %}
 
 package:
   name: {{ name|lower }}
@@ -19,14 +19,15 @@ requirements:
   build:
     - python
     - setuptools
+    - numpy
 
   run:
     - python
-    - numpy >=1.13
-    - pymatgen >=2017.7.4
-    - monty >=0.9.6
-    - pymongo >=2.8
+    - pymatgen >=2018.2.13
+    - monty >=1.0.2
+    - pymongo >=2.8.0
     - smoqe
+    - pybtex >=0.21
     - enum34  # [py27]
 
 test:


### PR DESCRIPTION
numpy was causing trouble only being a run requirement for pymatgen-db. I built the current version locally on my Mac w/ py2 w/o errors.

Two more points:
1) I still do PR rather than direct push as I'm new to this repo and am afraid to mess things up.

2) Is my part done for updating atomate version? It seems like if I upload the package (e.g. atomate py2 package on mac) it uploads under my username on Anaconda. I don't really know if I should try to upload it here https://anaconda.org/matsci/atomate/files and if yes how?

Thanks.